### PR TITLE
Add JAFFE dataset

### DIFF
--- a/faces.py
+++ b/faces.py
@@ -44,6 +44,8 @@ def train():
             "Output intermediate results after each epoch.")
     parser.add_argument('--use-yalefaces', action='store_true', help=
             "Use YaleFaces data instead of RaFD")
+    parser.add_argument('--use-jaffe', action='store_true', help=
+            "Use JAFFE data instead of RaFD")
 
     args = parser.parse_args(sys.argv[2:])
 
@@ -62,6 +64,7 @@ def train():
         kernels_per_layer     = args.kernels_per_layer,
         generate_intermediate = args.visualize,
         use_yale              = args.use_yalefaces,
+        use_jaffe             = args.use_jaffe,
         verbose               = True,
     )
 
@@ -125,5 +128,3 @@ if __name__ == '__main__':
 
     if cmd is not None:
         cmd()
-
-

--- a/faces/generate.py
+++ b/faces/generate.py
@@ -291,11 +291,11 @@ class GenParser:
 
         # Interpolate
         if use_yale:
-            id_idx = np.arange(0, NUM_YALE_ID)
+            id_idx = np.arange(0, params['num_ids'])
             ps_idx = np.arange(0, NUM_YALE_POSES)
             lt_idx = np.arange(0, 4)
         else:
-            id_idx = np.arange(0, NUM_ID)
+            id_idx = np.arange(0, params['num_ids'])
             em_idx = np.arange(0, Emotion.length())
             or_idx = np.arange(0, 2)
 

--- a/faces/instance.py
+++ b/faces/instance.py
@@ -262,10 +262,11 @@ class JAFFEInstances:
 
         instances = [JAFFEInstance(self.directory, fname, image_size)
                      for fname in self.filenames]
-        inst_idents = np.empty((self.num_instances, self.num_identities))
+        inst_idents = np.zeros((self.num_instances, self.num_identities))
         for idx, inst in enumerate(instances):
             # each row in inst_idents is a one-hot encoding of identity idx
             inst_idents[idx, self.identity_map[inst.identity]] = 1
+
         inst_orient = np.tile((0, 1), self.num_instances).reshape(-1,2)
         ratings = self.load_semantic_ratings()
         # Note: there are some scored instance N's with no instance file!

--- a/faces/train.py
+++ b/faces/train.py
@@ -116,6 +116,8 @@ def train_model(data_dir, output_dir, model_file='', batch_size=32,
         generate_intermediate (bool): Whether or not to generate intermediate results.
     """
 
+    data_dir = os.path.expanduser(data_dir)
+
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
 
@@ -135,14 +137,21 @@ def train_model(data_dir, output_dir, model_file='', batch_size=32,
         if verbose:
             print("Loaded model %d identities from {}".format(model.model_file))
     else:
+        # TODO: Refactor this to a more elegant way to determine params by dataset
+        initial_shape = (5,4)
+        if use_yale:
+            initial_shape = (6,8)
+        if use_jaffe:
+            initial_shape = (4,4)
+
         model = build_model(
             identity_len  = instances.num_identities,
             deconv_layers = deconv_layers,
             num_kernels   = kernels_per_layer,
             optimizer     = optimizer,
-            initial_shape = (5,4) if not use_yale else (6,8),
+            initial_shape = initial_shape,
             use_yale      = use_yale,
-            use_jaffe      = use_jaffe,
+            use_jaffe     = use_jaffe,
         )
         if verbose:
             print("Built model with:")
@@ -155,7 +164,8 @@ def train_model(data_dir, output_dir, model_file='', batch_size=32,
 
     if generate_intermediate:
         intermediate_dir = os.path.join(output_dir, 'intermediate.d{}.{}'.format(deconv_layers, optimizer))
-        callbacks.append( GenerateIntermediate(intermediate_dir, instances.num_identities, use_yale=use_yale, use_jaffe=use_jaffe) )
+        callbacks.append( GenerateIntermediate(intermediate_dir, instances.num_identities,
+                                               use_yale=use_yale, use_jaffe=use_jaffe) )
 
     model_path = os.path.join(output_dir, 'FaceGen.{}.model.d{}.{}.h5'
             .format('YaleFaces' if use_yale else 'JAFFE' if use_jaffe else 'RaFD', deconv_layers, optimizer))


### PR DESCRIPTION
I wanted to take this code for a spin, but the RaFD data is pretty locked down without a .edu mailing address.

Here's an interesting dataset of 10 female Japanese faces acting out standard expressions, with FACS scores by a human panel. You get finer-grained scoring with multiple emotions per instance.
http://www.kasrl.org/jaffe_info.html
(noncommercial use, but available to regular Joes like me for download)

Not meant for merge, as something's Not Quite Right and the identity images I get look like this:
![00000](https://cloud.githubusercontent.com/assets/1497207/21860667/7f165622-d7e6-11e6-86f0-1f32ba8bca99.jpg)

Sending this along in case anyone else wants it as a starting place. (also, at three datasets, you're ready for some refactoring).
